### PR TITLE
Support for sending addressComponents, and receiving identified result sets

### DIFF
--- a/Geocodio/Geocodio.cs
+++ b/Geocodio/Geocodio.cs
@@ -93,13 +93,37 @@ namespace Geocodio
         }
 
         /// <summary>
-        /// Executes a batch request to look up multiple addresses
+        /// Executes a batch request to look up multiple addresses. Pass in a Dictionary of AddressRequest objects bound by an integer ID key.
         /// </summary>
         /// <param name="addresses"></param>
         /// <remarks>You can batch up to 10000 addresses in a single request</remarks>
         /// <returns></returns>
-        public GeocodioBatchResponse GetGeolocations(Object addresses)
-        {
+        public GeocodioBatchResponse GetGeolocations(Dictionary<int,GeocodioAddressRequest> addresses) {
+            return this.GetGeolocations((Object)addresses);
+        }
+        /// <summary>
+        /// Executes a batch request to look up multiple addresses. Pass in a Dictionary of strings bound by an integer ID key.
+        /// </summary>
+        /// <param name="addresses"></param>
+        /// <remarks>You can batch up to 10000 addresses in a single request</remarks>
+        /// <returns></returns>
+        public GeocodioBatchResponse GetGeolocations(Dictionary<int,String> addresses) {
+            return this.GetGeolocations((Object)addresses);
+        }
+        /// <summary>
+        /// Executes a batch request to look up multiple addresses. Pass in an array of strings.
+        /// </summary>
+        /// <param name="addresses"></param>
+        /// <remarks>You can batch up to 10000 addresses in a single request</remarks>
+        /// <returns></returns>
+        public GeocodioBatchResponse GetGeolocations(String[] addresses) {
+            return this.GetGeolocations((Object)addresses);
+        }
+
+
+
+
+        private GeocodioBatchResponse GetGeolocations(Object addresses)
 
             //some sanity checks
             if (addresses == null)
@@ -108,14 +132,13 @@ namespace Geocodio
                 throw new ArgumentNullException(nameof(addresses));
             }
 
+            //too many addresses in the batch
             if (addresses.GetType()==typeof(String[]) && (((String[])addresses).Length > 10000))
             {
-                //too many addresses in the batch
                 throw new InvalidOperationException("Geocodio only allows a maximum of 10000 addresses per batch (array of string addresses)");
-            } else if (addresses.GetType() == typeof(List<GeocodioAddressRequest>) && (((List<GeocodioAddressRequest>)addresses).Count > 10000)) {
-				//too many addresses in the batch
-				throw new InvalidOperationException("Geocodio only allows a maximum of 10000 addresses per batch (Dictionary of identified addresses)");
-			}
+            } else if (addresses.GetType() == typeof(Dictionary<int,Object>) && (((Dictionary<int,Object>)addresses).Count > 10000)) {
+                throw new InvalidOperationException("Geocodio only allows a maximum of 10000 addresses per batch (Dictionary of identified addresses)");
+            }
 
             if (string.IsNullOrWhiteSpace(ApiKey))
             {

--- a/Geocodio/Geocodio.cs
+++ b/Geocodio/Geocodio.cs
@@ -112,7 +112,7 @@ namespace Geocodio
             {
                 //too many addresses in the batch
                 throw new InvalidOperationException("Geocodio only allows a maximum of 10000 addresses per batch (array of string addresses)");
-            } else if (addresses.GetType() == typeof(List<GeocodioAddressComponents>) && (((List<GeocodioAddressComponents>)addresses).Count > 10000)) {
+            } else if (addresses.GetType() == typeof(List<GeocodioAddressRequest>) && (((List<GeocodioAddressRequest>)addresses).Count > 10000)) {
 				//too many addresses in the batch
 				throw new InvalidOperationException("Geocodio only allows a maximum of 10000 addresses per batch (Dictionary of identified addresses)");
 			}

--- a/Geocodio/Geocodio.cs
+++ b/Geocodio/Geocodio.cs
@@ -98,7 +98,7 @@ namespace Geocodio
         /// <param name="addresses"></param>
         /// <remarks>You can batch up to 10000 addresses in a single request</remarks>
         /// <returns></returns>
-        public GeocodioBatchResponse GetGeolocations(string[] addresses)
+        public GeocodioBatchResponse GetGeolocations(Object addresses)
         {
 
             //some sanity checks
@@ -108,11 +108,14 @@ namespace Geocodio
                 throw new ArgumentNullException(nameof(addresses));
             }
 
-            if (addresses.Length > 10000)
+            if (addresses.GetType()==typeof(String[]) && (((String[])addresses).Length > 10000))
             {
                 //too many addresses in the batch
-                throw new InvalidOperationException("Geocodio only allows a maximum of 10000 addresses per batch");
-            }
+                throw new InvalidOperationException("Geocodio only allows a maximum of 10000 addresses per batch (array of string addresses)");
+            } else if (addresses.GetType() == typeof(List<GeocodioAddressComponents>) && (((List<GeocodioAddressComponents>)addresses).Count > 10000)) {
+				//too many addresses in the batch
+				throw new InvalidOperationException("Geocodio only allows a maximum of 10000 addresses per batch (Dictionary of identified addresses)");
+			}
 
             if (string.IsNullOrWhiteSpace(ApiKey))
             {

--- a/Geocodio/GeocodioAddressComponents.cs
+++ b/Geocodio/GeocodioAddressComponents.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -16,5 +16,15 @@ namespace Geocodio
         public string County { get; set; }
         public string State { get; set; }
         public string Zip { get; set; }
+		public string FormattedStreet { get; set; }
     }
+	public class GeocodioAddressRequest {
+		public string number { get; set; }
+		public string street { get; set; }
+		public string city { get; set; }
+		public string county { get; set; }
+		public string state { get; set; }
+		public string zip { get; set; }
+		public string address { get; set; }
+	}
 }

--- a/Geocodio/GeocodioAddressComponents.cs
+++ b/Geocodio/GeocodioAddressComponents.cs
@@ -16,15 +16,15 @@ namespace Geocodio
         public string County { get; set; }
         public string State { get; set; }
         public string Zip { get; set; }
-		public string FormattedStreet { get; set; }
+        public string FormattedStreet { get; set; }
     }
-	public class GeocodioAddressRequest {
-		public string number { get; set; }
-		public string street { get; set; }
-		public string city { get; set; }
-		public string county { get; set; }
-		public string state { get; set; }
-		public string zip { get; set; }
-		public string address { get; set; }
-	}
+    public class GeocodioAddressRequest {
+        public string number { get; set; }
+        public string street { get; set; }
+        public string city { get; set; }
+        public string county { get; set; }
+        public string state { get; set; }
+        public string zip { get; set; }
+        public string address { get; set; }
+    }
 }

--- a/Geocodio/GeocodioBatchResponse.cs
+++ b/Geocodio/GeocodioBatchResponse.cs
@@ -18,19 +18,31 @@ namespace Geocodio
 
             //create list
             Results = new List<GeocodioBatchResult>();
-
-            //iterate through each result
-            foreach(var result in response["results"])
-            {
-                //create new result
-                var geoRes = new GeocodioBatchResult()
-                {
-                    Query = (string)result["query"],
-                    Response = new GeocodioResponse(result["response"])
-                };
-
-                Results.Add(geoRes);
-            }
+            
+            Object contents = null;
+			try {
+				contents = ((IDictionary<string, JToken>)response).ToDictionary(
+					pair => pair.Key,
+					pair => (JObject)pair.Value
+				);
+				foreach (KeyValuePair<string, JObject> result in ((Dictionary<string, JObject>)contents)) {
+					Results.Add(new GeocodioBatchResult() {
+						ID = result.Key,
+						Query = (string)result.Value["query"],
+						Response = new GeocodioResponse(result.Value["response"])
+					});
+				}
+			} catch (Exception e) {
+				int count = 0;
+				foreach (var result in response["results"]) {
+					count++;
+					Results.Add(new GeocodioBatchResult() {
+						ID = count.ToString(),
+						Query = (string)result["query"],
+						Response = new GeocodioResponse(result["response"])
+					});
+				}
+			}
 
         }
         #endregion

--- a/Geocodio/GeocodioBatchResponse.cs
+++ b/Geocodio/GeocodioBatchResponse.cs
@@ -1,9 +1,10 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace Geocodio
 {
@@ -15,24 +16,21 @@ namespace Geocodio
 
         #region Constructor
         public GeocodioBatchResponse(JToken response) {
-
             //create list
             Results = new List<GeocodioBatchResult>();
-            
-            Object contents = null;
+
+			Object contents = null;
 			try {
-				contents = ((IDictionary<string, JToken>)response).ToDictionary(
-					pair => pair.Key,
-					pair => (JObject)pair.Value
-				);
+				contents = response["results"].ToObject<IDictionary<string, JObject>>();
 				foreach (KeyValuePair<string, JObject> result in ((Dictionary<string, JObject>)contents)) {
 					Results.Add(new GeocodioBatchResult() {
 						ID = result.Key,
-						Query = (string)result.Value["query"],
+						Query = result.Value["query"],
 						Response = new GeocodioResponse(result.Value["response"])
 					});
 				}
 			} catch (Exception e) {
+				Log.add(Log.LogType.Error, e.Message+"<br />"+e.StackTrace, "GeocodioBatchResponse");
 				int count = 0;
 				foreach (var result in response["results"]) {
 					count++;

--- a/Geocodio/GeocodioBatchResponse.cs
+++ b/Geocodio/GeocodioBatchResponse.cs
@@ -18,30 +18,27 @@ namespace Geocodio
         public GeocodioBatchResponse(JToken response) {
             //create list
             Results = new List<GeocodioBatchResult>();
-
-			Object contents = null;
-			try {
-				contents = response["results"].ToObject<IDictionary<string, JObject>>();
-				foreach (KeyValuePair<string, JObject> result in ((Dictionary<string, JObject>)contents)) {
-					Results.Add(new GeocodioBatchResult() {
-						ID = result.Key,
-						Query = result.Value["query"],
-						Response = new GeocodioResponse(result.Value["response"])
-					});
-				}
-			} catch (Exception e) {
-				Log.add(Log.LogType.Error, e.Message+"<br />"+e.StackTrace, "GeocodioBatchResponse");
-				int count = 0;
-				foreach (var result in response["results"]) {
-					count++;
-					Results.Add(new GeocodioBatchResult() {
-						ID = count.ToString(),
-						Query = (string)result["query"],
-						Response = new GeocodioResponse(result["response"])
-					});
-				}
-			}
-
+            Object contents = null;
+            try {
+                contents = response["results"].ToObject<IDictionary<string, JObject>>();
+                foreach (KeyValuePair<string, JObject> result in ((Dictionary<string, JObject>)contents)) {
+                    Results.Add(new GeocodioBatchResult() {
+                        ID = result.Key,
+                        Query = result.Value["query"],
+                        Response = new GeocodioResponse(result.Value["response"])
+                    });
+                }
+            } catch (Exception e) {
+                int count = 0;
+                foreach (var result in response["results"]) {
+                    count++;
+                    Results.Add(new GeocodioBatchResult() {
+                        ID = count.ToString(),
+                        Query = (string)result["query"],
+                        Response = new GeocodioResponse(result["response"])
+                    });
+                }
+            }
         }
         #endregion
     }

--- a/Geocodio/GeocodioBatchResult.cs
+++ b/Geocodio/GeocodioBatchResult.cs
@@ -8,6 +8,7 @@ namespace Geocodio
 {
     public class GeocodioBatchResult
     {
+        public string ID { get; set; }
         public string Query { get; set; }
         public GeocodioResponse Response { get; set; }
     }

--- a/Geocodio/GeocodioBatchResult.cs
+++ b/Geocodio/GeocodioBatchResult.cs
@@ -9,7 +9,7 @@ namespace Geocodio
     public class GeocodioBatchResult
     {
         public string ID { get; set; }
-        public string Query { get; set; }
+        public Object Query { get; set; }
         public GeocodioResponse Response { get; set; }
     }
 }

--- a/Geocodio/GeocodioResponse.cs
+++ b/Geocodio/GeocodioResponse.cs
@@ -66,6 +66,11 @@ namespace Geocodio
                 //add to the collection of results
                 Results.Add(geoResult);
             }
+            if (Results.Count==0 && response["error"]!=null) {
+				Results.Add(new GeocodioResult() {
+					Error = response["error"].ToString()
+				});
+			}
         }
         #endregion
 

--- a/Geocodio/GeocodioResponse.cs
+++ b/Geocodio/GeocodioResponse.cs
@@ -52,6 +52,7 @@ namespace Geocodio
                         County = (string)addrComp?["county"],
                         State = (string)addrComp?["state"],
                         Zip = (string)addrComp?["zip"],
+                        FormattedStreet = (string)result["formatted_street"],
                     },
                     FormattedAddress = (string)result["formatted_address"],
                     Location = new GeocodioLocation()

--- a/Geocodio/GeocodioResult.cs
+++ b/Geocodio/GeocodioResult.cs
@@ -14,6 +14,7 @@ namespace Geocodio
         public string FormattedAddress { get; set; }
         public GeocodioLocation Location { get; set; }
         public decimal Accuracy { get; set; }
+        public string Error { get; set; }
         #endregion
 
     }


### PR DESCRIPTION
You can send a JSON object optionally with an ID, and optionally with address components instead of a string. Original version only supported sending an array of strings for the query. Now supports both.

So we therefore need to be able to receive the JSON object response containing a query object (address components) and the result set matched to an ID that we sent in.

Also added the FormattedStreet property, since that is sent back as well.
And added support for the Error field which comes back when the result set is empty.

Extended (duplicate handler, & split apart to see the stages) example usage with new system:

```
                foreach(Address target in targets.Values.ToList()) {
                    String fullAddress=target.printFull();
                    target.geoRequest=new GeocodioAddressRequest() {
                        address = fullAddress,
                        city = target.City,
                        state = target.State,
                        zip = target.Zip,
                        street = target.Line1
                    };
                    if (!dispatchAddressList.ContainsValue(fullAddress)) {
                        dispatchAddressList.Add(target.ID, fullAddress);
                        dispatchAddresses.Add(target.ID,target);
                    } else {
                        int origin= dispatchAddressList.FirstOrDefault(x=>x.Value==fullAddress).Key;
                        if (!duplicateAddresses.ContainsKey(origin)) duplicateAddresses.Add(origin,new List<Address>() { 
                            target
                        });
                        else duplicateAddresses[origin].Add(target);
                    }
                }
                Dictionary<int,GeocodioAddressRequest> dispatch=new Dictionary<int,GeocodioAddressRequest>(); 
                foreach (Address addy in dispatchAddresses.Values) dispatch.Add(addy.ID,addy.geoRequest);

                Geocodio.Geocodio geo = new Geocodio.Geocodio(SystemVars.getSystemVar("GeoCoding API").Value);
                GeocodioBatchResponse bresponse=geo.GetGeolocations(dispatch);

                foreach(GeocodioBatchResult bresult in bresponse.Results) {
                    int ident= bresult.ID.ToInt32();
                    Address target = targets[ident];

                    GeocodioResult result=bresult.Response.Results.First();
                    if (String.IsNullOrEmpty(result.Error)) {
                        // do stuff with it.. it's valid
                    }
                }
```
